### PR TITLE
fix: unsupported compute_35 error when building with CUDA 12+

### DIFF
--- a/cmake/cuda.cmake
+++ b/cmake/cuda.cmake
@@ -11,9 +11,9 @@ if(BUILD_ON_JETSON)
   set(fd_known_gpu_archs10 "53 62 72")
 else()
   message("Using New Release Strategy - All Arches Packge")
-  set(fd_known_gpu_archs "35 50 52 60 61 70 75 80 86")
-  set(fd_known_gpu_archs10 "35 50 52 60 61 70 75")
-  set(fd_known_gpu_archs11 "50 60 61 70 75 80")
+  set(fd_known_gpu_archs "70 75 80 86")
+  set(fd_known_gpu_archs10 "70 75")
+  set(fd_known_gpu_archs11 "70 75 80")
 endif()
 
 ######################################################################################


### PR DESCRIPTION
fix: unsupported compute_35 error when building with CUDA 12+
referenced from:
- https://github.com/PaddlePaddle/FastDeploy/issues/2024


### PR types(PR类型)
<!-- One of PR types [ Model | Backend | Serving | Quantization | Doc | Bug Fix | Other] -->
Bug Fix

### Description
<!-- Describe what this PR does -->
This PR fixes a build failure when compiling with CUDA 12 or newer, caused by the presence of unsupported GPU architectures such as `compute_35` in `CMAKE_CUDA_ARCHITECTURES`.

CUDA 12 has dropped support for legacy compute capabilities (≤ 5.0), and attempting to build with `compute_35` results in:
- changes
  - Removed legacy architectures (`compute_35`, `50`, `52`, etc.) from `CMAKE_CUDA_ARCHITECTURES`
  - Set default architectures to `70;75;80;86;89;90` (Turing, Ampere, Ada, Hopper)

